### PR TITLE
Decorator and docstring syntax fix

### DIFF
--- a/ops.py
+++ b/ops.py
@@ -4,11 +4,12 @@ import tensorflow as tf
 from tensorflow.contrib.framework.python.ops import add_arg_scope
 
 @add_arg_scope
-"""
-The gate convolution is made with reference to Deepfillv1(https://github.com/JiahuiYu/generative_inpainting)
-"""
 def gate_conv(x_in, cnum, ksize, stride=1, rate=1, name='conv',
              padding='SAME', activation='leaky_relu', use_lrn=True,training=True):
+    """
+    The gate convolution is made with reference to Deepfillv1(https://github.com/JiahuiYu/generative_inpainting)
+    """
+
     assert padding in ['SYMMETRIC', 'SAME', 'REFELECT']
     if padding == 'SYMMETRIC' or padding == 'REFELECT':
         p = int(rate*(ksize-1)/2)


### PR DESCRIPTION
removed incorrect placement of docstring. returns `invalid syntax` error.